### PR TITLE
Add Deserialize impls, a new Client constructor, and some QoL features

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -96,6 +96,15 @@ impl Client {
         Ok(Self::new(connector, None, endpoint))
     }
 
+    /// Create a connection to APNs using the raw PEM-formatted certificate and
+    /// key, extracted from the provider client certificate you obtain from your
+    /// [Apple developer account](https://developer.apple.com/account/).
+    pub fn certificate_parts(cert: &[u8], key: &[u8], endpoint: Endpoint) -> Result<Client, Error> {
+        let connector = AlpnConnector::with_client_cert(cert, key)?;
+
+        Ok(Self::new(connector, None, endpoint))
+    }
+
     /// Create a connection to APNs using system certificates, signing every
     /// request with a signature using a private key, key id and team id
     /// provisioned from your [Apple developer

--- a/src/request/notification/localized.rs
+++ b/src/request/notification/localized.rs
@@ -6,7 +6,7 @@ use std::{
     borrow::Cow,
 };
 
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct LocalizedAlert<'a> {
     title: &'a str,

--- a/src/request/notification/localized.rs
+++ b/src/request/notification/localized.rs
@@ -40,8 +40,9 @@ pub struct LocalizedAlert<'a> {
 ///
 /// ```rust
 /// # use a2::request::notification::{LocalizedNotificationBuilder, NotificationBuilder};
-/// # fn main() {
-/// let mut builder = LocalizedNotificationBuilder::new("Hi there", "What's up?");
+/// let mut builder = LocalizedNotificationBuilder::new();
+/// builder.set_title("Hi there");
+/// builder.set_body("What's up?");
 /// builder.set_badge(420);
 /// builder.set_category("cat1");
 /// builder.set_sound("prööt");
@@ -55,8 +56,8 @@ pub struct LocalizedAlert<'a> {
 /// builder.set_loc_args(&["narf", "derp"]);
 /// let payload = builder.build("device_id", Default::default())
 ///   .to_json_string().unwrap();
-/// # }
 /// ```
+#[derive(Default)]
 pub struct LocalizedNotificationBuilder<'a> {
     alert: LocalizedAlert<'a>,
     badge: Option<u32>,
@@ -66,57 +67,70 @@ pub struct LocalizedNotificationBuilder<'a> {
 }
 
 impl<'a> LocalizedNotificationBuilder<'a> {
-    /// Creates a new builder with the minimum amount of content.
+    /// Creates a new builder.
     ///
     /// ```rust
     /// # use a2::request::notification::{LocalizedNotificationBuilder, NotificationBuilder};
-    /// # fn main() {
-    /// let payload = LocalizedNotificationBuilder::new("a title", "a body")
+    /// let payload = LocalizedNotificationBuilder::new()
     ///     .build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"body\":\"a body\",\"title\":\"a title\"},\"mutable-content\":0}}",
+    ///     "{\"aps\":{\"alert\":{},\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
-    /// # }
     /// ```
-    pub fn new(
-        title: &'a str,
-        body: &'a str
-    ) -> LocalizedNotificationBuilder<'a>
-    {
-        LocalizedNotificationBuilder {
-            alert: LocalizedAlert {
-                title: Some(title),
-                body: Some(body),
-                title_loc_key: None,
-                title_loc_args: None,
-                action_loc_key: None,
-                loc_key: None,
-                loc_args: None,
-                launch_image: None,
-            },
-            badge: None,
-            sound: None,
-            category: None,
-            mutable_content: 0,
-        }
+    pub fn new() -> LocalizedNotificationBuilder<'a> {
+        Self::default()
+    }
+
+    /// Set the title
+    ///
+    /// ```rust
+    /// # use a2::request::notification::{LocalizedNotificationBuilder, NotificationBuilder};
+    /// let payload = LocalizedNotificationBuilder::new()
+    ///     .set_title("a title")
+    ///     .build("token", Default::default());
+    ///
+    /// assert_eq!(
+    ///     "{\"aps\":{\"alert\":{\"title\":\"a title\"},\"mutable-content\":0}}",
+    ///     &payload.to_json_string().unwrap()
+    /// );
+    /// ```
+    pub fn set_title(&mut self, title: &'a str) -> &mut Self {
+        self.alert.title = Some(title);
+        self
+    }
+
+    /// Set the body
+    ///
+    /// ```rust
+    /// # use a2::request::notification::{LocalizedNotificationBuilder, NotificationBuilder};
+    /// let payload = LocalizedNotificationBuilder::new()
+    ///     .set_body("a body")
+    ///     .build("token", Default::default());
+    ///
+    /// assert_eq!(
+    ///     "{\"aps\":{\"alert\":{\"body\":\"a body\"},\"mutable-content\":0}}",
+    ///     &payload.to_json_string().unwrap()
+    /// );
+    /// ```
+    pub fn set_body(&mut self, body: &'a str) -> &mut Self {
+        self.alert.body = Some(body);
+        self
     }
 
     /// A number to show on a badge on top of the app icon.
     ///
     /// ```rust
     /// # use a2::request::notification::{LocalizedNotificationBuilder, NotificationBuilder};
-    /// # fn main() {
-    /// let mut builder = LocalizedNotificationBuilder::new("a title", "a body");
+    /// let mut builder = LocalizedNotificationBuilder::new();
     /// builder.set_badge(4);
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"body\":\"a body\",\"title\":\"a title\"},\"badge\":4,\"mutable-content\":0}}",
+    ///     "{\"aps\":{\"alert\":{},\"badge\":4,\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
-    /// # }
     /// ```
     pub fn set_badge(&mut self, badge: u32) -> &mut Self
     {
@@ -128,16 +142,14 @@ impl<'a> LocalizedNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{LocalizedNotificationBuilder, NotificationBuilder};
-    /// # fn main() {
-    /// let mut builder = LocalizedNotificationBuilder::new("a title", "a body");
+    /// let mut builder = LocalizedNotificationBuilder::new();
     /// builder.set_sound("ping");
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"body\":\"a body\",\"title\":\"a title\"},\"mutable-content\":0,\"sound\":\"ping\"}}",
+    ///     "{\"aps\":{\"alert\":{},\"mutable-content\":0,\"sound\":\"ping\"}}",
     ///     &payload.to_json_string().unwrap()
     /// );
-    /// # }
     /// ```
     pub fn set_sound(&mut self, sound: &'a str) -> &mut Self
     {
@@ -150,16 +162,14 @@ impl<'a> LocalizedNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{LocalizedNotificationBuilder, NotificationBuilder};
-    /// # fn main() {
-    /// let mut builder = LocalizedNotificationBuilder::new("a title", "a body");
+    /// let mut builder = LocalizedNotificationBuilder::new();
     /// builder.set_category("cat1");
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"body\":\"a body\",\"title\":\"a title\"},\"category\":\"cat1\",\"mutable-content\":0}}",
+    ///     "{\"aps\":{\"alert\":{},\"category\":\"cat1\",\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
-    /// # }
     /// ```
     pub fn set_category(&mut self, category: &'a str) -> &mut Self
     {
@@ -171,16 +181,14 @@ impl<'a> LocalizedNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{LocalizedNotificationBuilder, NotificationBuilder};
-    /// # fn main() {
-    /// let mut builder = LocalizedNotificationBuilder::new("a title", "a body");
+    /// let mut builder = LocalizedNotificationBuilder::new();
     /// builder.set_title_loc_key("play");
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"body\":\"a body\",\"title\":\"a title\",\"title-loc-key\":\"play\"},\"mutable-content\":0}}",
+    ///     "{\"aps\":{\"alert\":{\"title-loc-key\":\"play\"},\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
-    /// # }
     /// ```
     pub fn set_title_loc_key(&mut self, key: &'a str) -> &mut Self
     {
@@ -192,16 +200,14 @@ impl<'a> LocalizedNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{LocalizedNotificationBuilder, NotificationBuilder};
-    /// # fn main() {
-    /// let mut builder = LocalizedNotificationBuilder::new("a title", "a body");
+    /// let mut builder = LocalizedNotificationBuilder::new();
     /// builder.set_title_loc_args(&["foo", "bar"]);
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"body\":\"a body\",\"title\":\"a title\",\"title-loc-args\":[\"foo\",\"bar\"]},\"mutable-content\":0}}",
+    ///     "{\"aps\":{\"alert\":{\"title-loc-args\":[\"foo\",\"bar\"]},\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
-    /// # }
     /// ```
     pub fn set_title_loc_args<S>(
         &mut self,
@@ -223,16 +229,14 @@ impl<'a> LocalizedNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{LocalizedNotificationBuilder, NotificationBuilder};
-    /// # fn main() {
-    /// let mut builder = LocalizedNotificationBuilder::new("a title", "a body");
+    /// let mut builder = LocalizedNotificationBuilder::new();
     /// builder.set_action_loc_key("stop");
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"action-loc-key\":\"stop\",\"body\":\"a body\",\"title\":\"a title\"},\"mutable-content\":0}}",
+    ///     "{\"aps\":{\"alert\":{\"action-loc-key\":\"stop\"},\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
-    /// # }
     /// ```
     pub fn set_action_loc_key(&mut self, key: &'a str) -> &mut Self
     {
@@ -244,16 +248,14 @@ impl<'a> LocalizedNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{LocalizedNotificationBuilder, NotificationBuilder};
-    /// # fn main() {
-    /// let mut builder = LocalizedNotificationBuilder::new("a title", "a body");
+    /// let mut builder = LocalizedNotificationBuilder::new();
     /// builder.set_loc_key("lol");
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"body\":\"a body\",\"loc-key\":\"lol\",\"title\":\"a title\"},\"mutable-content\":0}}",
+    ///     "{\"aps\":{\"alert\":{\"loc-key\":\"lol\",},\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
-    /// # }
     /// ```
     pub fn set_loc_key(&mut self, key: &'a str) -> &mut Self
     {
@@ -265,16 +267,14 @@ impl<'a> LocalizedNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{LocalizedNotificationBuilder, NotificationBuilder};
-    /// # fn main() {
-    /// let mut builder = LocalizedNotificationBuilder::new("a title", "a body");
+    /// let mut builder = LocalizedNotificationBuilder::new();
     /// builder.set_loc_args(&["omg", "foo"]);
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"body\":\"a body\",\"loc-args\":[\"omg\",\"foo\"],\"title\":\"a title\"},\"mutable-content\":0}}",
+    ///     "{\"aps\":{\"alert\":{\"loc-args\":[\"omg\",\"foo\"]},\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
-    /// # }
     /// ```
     pub fn set_loc_args<S>(
         &mut self,
@@ -296,16 +296,14 @@ impl<'a> LocalizedNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{LocalizedNotificationBuilder, NotificationBuilder};
-    /// # fn main() {
-    /// let mut builder = LocalizedNotificationBuilder::new("a title", "a body");
+    /// let mut builder = LocalizedNotificationBuilder::new();
     /// builder.set_launch_image("cat.png");
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"body\":\"a body\",\"launch-image\":\"cat.png\",\"title\":\"a title\"},\"mutable-content\":0}}",
+    ///     "{\"aps\":{\"alert\":{\"launch-image\":\"cat.png\"},\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
-    /// # }
     /// ```
     pub fn set_launch_image(&mut self, image: &'a str) -> &mut Self
     {
@@ -317,16 +315,14 @@ impl<'a> LocalizedNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{LocalizedNotificationBuilder, NotificationBuilder};
-    /// # fn main() {
-    /// let mut builder = LocalizedNotificationBuilder::new("a title", "a body");
+    /// let mut builder = LocalizedNotificationBuilder::new();
     /// builder.set_mutable_content();
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"body\":\"a body\",\"title\":\"a title\"},\"mutable-content\":1}}",
+    ///     "{\"aps\":{\"alert\":{},\"mutable-content\":1}}",
     ///     &payload.to_json_string().unwrap()
     /// );
-    /// # }
     /// ```
     pub fn set_mutable_content(&mut self) -> &mut Self
     {
@@ -360,7 +356,11 @@ mod tests {
 
     #[test]
     fn test_localized_notification_with_minimal_required_values() {
-        let payload = LocalizedNotificationBuilder::new("the title", "the body")
+        let mut builder = LocalizedNotificationBuilder::new();
+        builder
+            .set_title("the title")
+            .set_body("the body");
+        let payload = builder
             .build("device-token", Default::default())
             .to_json_string()
             .unwrap();
@@ -380,8 +380,10 @@ mod tests {
 
     #[test]
     fn test_localized_notification_with_full_data() {
-        let mut builder = LocalizedNotificationBuilder::new("the title", "the body");
+        let mut builder = LocalizedNotificationBuilder::new();
 
+        builder.set_title("the title");
+        builder.set_body("the body");
         builder.set_badge(420);
         builder.set_category("cat1");
         builder.set_sound("prööt");
@@ -443,8 +445,11 @@ mod tests {
             key_struct: SubData { nothing: "here" },
         };
 
-        let mut payload = LocalizedNotificationBuilder::new("the title", "the body")
-            .build("device-token", Default::default());
+        let mut builder = LocalizedNotificationBuilder::new();
+        builder
+            .set_title("the title")
+            .set_body("the body");
+        let mut payload = builder.build("device-token", Default::default());
 
         payload.add_custom_data("custom", &test_data).unwrap();
 

--- a/src/request/notification/localized.rs
+++ b/src/request/notification/localized.rs
@@ -9,26 +9,29 @@ use std::{
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct LocalizedAlert<'a> {
-    title: &'a str,
-    body: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<&'a str>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    title_loc_key: Option<&'a str>,
+    pub body: Option<&'a str>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    title_loc_args: Option<Vec<Cow<'a, str>>>,
+    pub title_loc_key: Option<&'a str>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    action_loc_key: Option<&'a str>,
+    pub title_loc_args: Option<Vec<Cow<'a, str>>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    loc_key: Option<&'a str>,
+    pub action_loc_key: Option<&'a str>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    loc_args: Option<Vec<Cow<'a, str>>>,
+    pub loc_key: Option<&'a str>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    launch_image: Option<&'a str>,
+    pub loc_args: Option<Vec<Cow<'a, str>>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub launch_image: Option<&'a str>,
 }
 
 /// A builder to create a localized APNs payload.
@@ -84,8 +87,8 @@ impl<'a> LocalizedNotificationBuilder<'a> {
     {
         LocalizedNotificationBuilder {
             alert: LocalizedAlert {
-                title: title,
-                body: body,
+                title: Some(title),
+                body: Some(body),
                 title_loc_key: None,
                 title_loc_args: None,
                 action_loc_key: None,

--- a/src/request/notification/localized.rs
+++ b/src/request/notification/localized.rs
@@ -6,7 +6,7 @@ use std::{
     borrow::Cow,
 };
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct LocalizedAlert<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/request/payload.rs
+++ b/src/request/payload.rs
@@ -93,7 +93,7 @@ impl<'a> Payload<'a> {
 }
 
 /// The pre-defined notification data.
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Default, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct APS<'a> {
     /// The notification content. Can be empty for silent notifications.

--- a/src/request/payload.rs
+++ b/src/request/payload.rs
@@ -93,7 +93,7 @@ impl<'a> Payload<'a> {
 }
 
 /// The pre-defined notification data.
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct APS<'a> {
     /// The notification content. Can be empty for silent notifications.
@@ -124,7 +124,7 @@ pub struct APS<'a> {
 }
 
 /// Different notification content types.
-#[derive(Serialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum APSAlert<'a> {
     /// Text-only notification.


### PR DESCRIPTION
- Serde's `Deserialize` is implemented for `APS` and its sub-structs.
- Added `Client::certificate_parts` for creating a client from the raw certificate and private key data.
- Made the properties of `LocalizedAlert` public (and all fields optional), to make constructing notifications easier.
- Implemented `Default` for some `APS` structs, to make constructing notifications easier.