### PR TITLE
Add "tcp" feature to Hyper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ futures = "0.3"
 http = "0.2"
 base64 = "0.13"
 log = "0.4"
-hyper = { version = "0.14", features = ["client", "http2"] }
+hyper = { version = "0.14", features = ["client", "http2", "tcp"] }
 hyper-alpn = "0.3"
 
 [dev-dependencies]


### PR DESCRIPTION
I had the same issue as #59 and #55 where I was getting this error:

```
thread 'main' panicked at 'executor must be set'
```

Adding "tcp" feature to Hyper fixed this (base on suggestions from @staninprague in #59).

Fixes #59 and Fixes #55