### PR TITLE
Add support for critical alerts

### DIFF
--- a/src/request/notification.rs
+++ b/src/request/notification.rs
@@ -3,7 +3,7 @@ mod default;
 mod options;
 mod web;
 
-pub use self::default::{DefaultAlert, DefaultNotificationBuilder};
+pub use self::default::{DefaultAlert, DefaultNotificationBuilder, DefaultSound};
 pub use self::options::{CollapseId, NotificationOptions, Priority};
 pub use self::web::{WebNotificationBuilder, WebPushAlert};
 

--- a/src/request/notification/default.rs
+++ b/src/request/notification/default.rs
@@ -57,6 +57,7 @@ pub struct DefaultAlert<'a> {
 ///
 /// ```rust
 /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+/// # use a2::request::payload::PayloadLike;
 /// # fn main() {
 /// let mut builder = DefaultNotificationBuilder::new()
 ///     .set_title("Hi there")
@@ -95,6 +96,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let payload = DefaultNotificationBuilder::new()
     ///     .set_title("a title")
@@ -102,7 +104,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///     .build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"body\":\"a body\",\"title\":\"a title\"},\"mutable-content\":0}}",
+    ///     "{\"aps\":{\"alert\":{\"title\":\"a title\",\"body\":\"a body\"},\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
     /// # }
@@ -140,6 +142,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_title("a title");
@@ -163,13 +166,14 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_critical(true, None);
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"mutable-content\":0,\"sound\":{\"critical\":1}}}",
+    ///     "{\"aps\":{\"sound\":{\"critical\":1},\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
     /// # }
@@ -190,6 +194,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_subtitle("a subtitle");
@@ -211,6 +216,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_body("a body");
@@ -232,6 +238,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_badge(4);
@@ -252,6 +259,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_title("a title")
@@ -259,7 +267,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"title\":\"a title\"},\"mutable-content\":0,\"sound\":{\"name\":\"ping\"}}}",
+    ///     "{\"aps\":{\"alert\":{\"title\":\"a title\"},\"sound\":{\"name\":\"ping\"},\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
     /// # }
@@ -275,6 +283,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_title("a title")
@@ -296,6 +305,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_title("a title")
@@ -318,6 +328,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_title("a title")
@@ -345,6 +356,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_title("a title")
@@ -352,7 +364,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"action-loc-key\":\"stop\",\"title\":\"a title\"},\"mutable-content\":0}}",
+    ///     "{\"aps\":{\"alert\":{\"title\":\"a title\",\"action-loc-key\":\"stop\"},\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
     /// # }
@@ -367,6 +379,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_title("a title")
@@ -374,7 +387,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"loc-key\":\"lol\",\"title\":\"a title\"},\"mutable-content\":0}}",
+    ///     "{\"aps\":{\"alert\":{\"title\":\"a title\",\"loc-key\":\"lol\"},\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
     /// # }
@@ -389,6 +402,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_title("a title")
@@ -396,7 +410,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"loc-args\":[\"omg\",\"foo\"],\"title\":\"a title\"},\"mutable-content\":0}}",
+    ///     "{\"aps\":{\"alert\":{\"title\":\"a title\",\"loc-args\":[\"omg\",\"foo\"]},\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
     /// # }
@@ -416,6 +430,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_title("a title")
@@ -423,7 +438,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"launch-image\":\"cat.png\",\"title\":\"a title\"},\"mutable-content\":0}}",
+    ///     "{\"aps\":{\"alert\":{\"title\":\"a title\",\"launch-image\":\"cat.png\"},\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
     /// # }
@@ -438,6 +453,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_title("a title")
@@ -459,6 +475,7 @@ impl<'a> DefaultNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{DefaultNotificationBuilder, NotificationBuilder};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = DefaultNotificationBuilder::new()
     ///     .set_title("a title")
@@ -511,28 +528,26 @@ impl<'a> Default for DefaultNotificationBuilder<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::value::to_value;
 
     #[test]
     fn test_default_notification_with_minimal_required_values() {
         let payload = DefaultNotificationBuilder::new()
             .set_title("the title")
             .set_body("the body")
-            .build("device-token", Default::default())
-            .to_json_string()
-            .unwrap();
+            .build("device-token", Default::default());
 
         let expected_payload = json!({
             "aps": {
                 "alert": {
-                    "title": "the title",
                     "body": "the body",
+                    "title": "the title",
                 },
                 "mutable-content": 0
             }
-        })
-        .to_string();
+        });
 
-        assert_eq!(expected_payload, payload);
+        assert_eq!(expected_payload, to_value(payload).unwrap());
     }
 
     #[test]
@@ -553,10 +568,7 @@ mod tests {
             .set_loc_key("PAUSE")
             .set_loc_args(&["narf", "derp"]);
 
-        let payload = builder
-            .build("device-token", Default::default())
-            .to_json_string()
-            .unwrap();
+        let payload = builder.build("device-token", Default::default());
 
         let expected_payload = json!({
             "aps": {
@@ -571,18 +583,17 @@ mod tests {
                     "title-loc-key": "STOP"
                 },
                 "badge": 420,
-                "category": "cat1",
-                "mutable-content": 1,
                 "sound": {
                     "critical": 1,
                     "name": "prööt",
                     "volume": 1.0,
                 },
+                "category": "cat1",
+                "mutable-content": 1,
             }
-        })
-        .to_string();
+        });
 
-        assert_eq!(expected_payload, payload);
+        assert_eq!(expected_payload, to_value(payload).unwrap());
     }
 
     #[test]
@@ -625,15 +636,14 @@ mod tests {
             },
             "aps": {
                 "alert": {
-                    "title": "the title",
                     "body": "the body",
+                    "title": "the title",
                 },
                 "mutable-content": 0,
             },
-        })
-        .to_string();
+        });
 
-        assert_eq!(expected_payload, payload.to_json_string().unwrap());
+        assert_eq!(expected_payload, to_value(payload).unwrap());
     }
 
     #[test]
@@ -664,8 +674,6 @@ mod tests {
 
         payload.add_custom_data("custom", &test_data).unwrap();
 
-        let payload_json = payload.to_json_string().unwrap();
-
         let expected_payload = json!({
             "custom": {
                 "key_str": "foo",
@@ -681,29 +689,25 @@ mod tests {
                 },
                 "mutable-content": 0
             }
-        })
-        .to_string();
+        });
 
-        assert_eq!(expected_payload, payload_json);
+        assert_eq!(expected_payload, to_value(payload).unwrap());
     }
 
     #[test]
     fn test_silent_notification_with_no_content() {
         let payload = DefaultNotificationBuilder::new()
             .set_content_available()
-            .build("device-token", Default::default())
-            .to_json_string()
-            .unwrap();
+            .build("device-token", Default::default());
 
         let expected_payload = json!({
             "aps": {
                 "content-available": 1,
                 "mutable-content": 0
             }
-        })
-        .to_string();
+        });
 
-        assert_eq!(expected_payload, payload);
+        assert_eq!(expected_payload, to_value(payload).unwrap());
     }
 
     #[test]
@@ -747,10 +751,9 @@ mod tests {
                     "nothing": "here"
                 }
             }
-        })
-        .to_string();
+        });
 
-        assert_eq!(expected_payload, payload.to_json_string().unwrap());
+        assert_eq!(expected_payload, to_value(payload).unwrap());
     }
 
     #[test]
@@ -774,9 +777,8 @@ mod tests {
                 "key_str": "foo",
                 "key_str2": "bar"
             }
-        })
-        .to_string();
+        });
 
-        assert_eq!(expected_payload, payload.to_json_string().unwrap());
+        assert_eq!(expected_payload, to_value(payload).unwrap());
     }
 }

--- a/src/request/notification/default.rs
+++ b/src/request/notification/default.rs
@@ -220,14 +220,13 @@ impl<'a> DefaultNotificationBuilder<'a> {
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"body\":\"a body\"},\"mutable-content\":0}}",
+    ///     "{\"aps\":{\"alert\":\"a body\",\"mutable-content\":0}}",
     ///     &payload.to_json_string().unwrap()
     /// );
     /// # }
     /// ```
     pub fn set_body(mut self, body: &'a str) -> Self {
         self.alert.body = Some(body);
-        self.has_edited_alert = true;
         self
     }
 
@@ -496,7 +495,7 @@ impl<'a> NotificationBuilder<'a> for DefaultNotificationBuilder<'a> {
             aps: APS {
                 alert: match self.has_edited_alert {
                     true => Some(APSAlert::Default(self.alert)),
-                    false => None,
+                    false => self.alert.body.map(APSAlert::Body),
                 },
                 badge: self.badge,
                 sound: if self.sound.critical != 0 {
@@ -681,9 +680,7 @@ mod tests {
                 }
             },
             "aps": {
-                "alert": {
-                    "body": "kulli"
-                },
+                "alert": "kulli",
                 "mutable-content": 0
             }
         });

--- a/src/request/notification/web.rs
+++ b/src/request/notification/web.rs
@@ -1,5 +1,5 @@
 use crate::request::notification::{NotificationBuilder, NotificationOptions};
-use crate::request::payload::{APSAlert, Payload, APS};
+use crate::request::payload::{APSAlert, APSSound, Payload, APS};
 use std::collections::BTreeMap;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -79,7 +79,7 @@ impl<'a> NotificationBuilder<'a> for WebNotificationBuilder<'a> {
             aps: APS {
                 alert: Some(APSAlert::WebPush(self.alert)),
                 badge: None,
-                sound: self.sound,
+                sound: self.sound.map(APSSound::WebPush),
                 content_available: None,
                 category: None,
                 mutable_content: None,

--- a/src/request/notification/web.rs
+++ b/src/request/notification/web.rs
@@ -16,6 +16,7 @@ pub struct WebPushAlert<'a> {
 ///
 /// ```rust
 /// # use a2::request::notification::{NotificationBuilder, WebNotificationBuilder, WebPushAlert};
+/// # use a2::request::payload::PayloadLike;
 /// # fn main() {
 /// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello", body: "World", action: "View"}, &["arg1"]);
 /// builder.set_sound("prööt");
@@ -34,12 +35,13 @@ impl<'a> WebNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{WebNotificationBuilder, NotificationBuilder, WebPushAlert};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello", body: "World", action: "View"}, &["arg1"]);
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"action\":\"View\",\"body\":\"World\",\"title\":\"Hello\"},\"url-args\":[\"arg1\"]}}",
+    ///     "{\"aps\":{\"alert\":{\"title\":\"Hello\",\"body\":\"World\",\"action\":\"View\"},\"url-args\":[\"arg1\"]}}",
     ///     &payload.to_json_string().unwrap()
     /// );
     /// # }
@@ -56,13 +58,14 @@ impl<'a> WebNotificationBuilder<'a> {
     ///
     /// ```rust
     /// # use a2::request::notification::{WebNotificationBuilder, NotificationBuilder, WebPushAlert};
+    /// # use a2::request::payload::PayloadLike;
     /// # fn main() {
     /// let mut builder = WebNotificationBuilder::new(WebPushAlert {title: "Hello", body: "World", action: "View"}, &["arg1"]);
     /// builder.set_sound("meow");
     /// let payload = builder.build("token", Default::default());
     ///
     /// assert_eq!(
-    ///     "{\"aps\":{\"alert\":{\"action\":\"View\",\"body\":\"World\",\"title\":\"Hello\"},\"sound\":\"meow\",\"url-args\":[\"arg1\"]}}",
+    ///     "{\"aps\":{\"alert\":{\"title\":\"Hello\",\"body\":\"World\",\"action\":\"View\"},\"sound\":\"meow\",\"url-args\":[\"arg1\"]}}",
     ///     &payload.to_json_string().unwrap()
     /// );
     /// # }
@@ -95,6 +98,8 @@ impl<'a> NotificationBuilder<'a> for WebNotificationBuilder<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::request::payload::PayloadLike;
+    use serde_json::Value;
 
     #[test]
     fn test_webpush_notification() {
@@ -113,15 +118,14 @@ mod tests {
         let expected_payload = json!({
             "aps": {
                 "alert": {
+                    "title": "Hello",
                     "body": "world",
                     "action": "View",
-                    "title": "Hello"
                 },
                 "url-args": ["arg1"]
             }
-        })
-        .to_string();
+        });
 
-        assert_eq!(expected_payload, payload);
+        assert_eq!(expected_payload, serde_json::from_str::<Value>(&payload).unwrap());
     }
 }

--- a/src/request/notification/web.rs
+++ b/src/request/notification/web.rs
@@ -82,7 +82,7 @@ impl<'a> NotificationBuilder<'a> for WebNotificationBuilder<'a> {
             aps: APS {
                 alert: Some(APSAlert::WebPush(self.alert)),
                 badge: None,
-                sound: self.sound.map(APSSound::WebPush),
+                sound: self.sound.map(APSSound::Sound),
                 content_available: None,
                 category: None,
                 mutable_content: None,

--- a/src/request/payload.rs
+++ b/src/request/payload.rs
@@ -230,8 +230,8 @@ pub enum APSAlert<'a> {
 #[derive(Serialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum APSSound<'a> {
-    /// A notification that supports all of the iOS features
-    Default(DefaultSound<'a>),
-    /// Safari web push notification
-    WebPush(&'a str),
+    /// A critical notification (supported only on >= iOS 12)
+    Critical(DefaultSound<'a>),
+    /// Name for a notification sound
+    Sound(&'a str),
 }

--- a/src/request/payload.rs
+++ b/src/request/payload.rs
@@ -1,6 +1,6 @@
 ///! Payload with `aps` and custom data
 use crate::error::Error;
-use crate::request::notification::{DefaultAlert, NotificationOptions, WebPushAlert};
+use crate::request::notification::{DefaultAlert, DefaultSound, NotificationOptions, WebPushAlert};
 use erased_serde::Serialize;
 use serde_json::{self, Value};
 use std::collections::BTreeMap;
@@ -104,7 +104,7 @@ pub struct APS<'a> {
 
     /// The name of the sound file to play when user receives the notification.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub sound: Option<&'a str>,
+    pub sound: Option<APSSound<'a>>,
 
     /// Set to one for silent notifications.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -132,4 +132,14 @@ pub enum APSAlert<'a> {
     Default(DefaultAlert<'a>),
     /// Safari web push notification
     WebPush(WebPushAlert<'a>),
+}
+
+/// Different notification sound types.
+#[derive(Serialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum APSSound<'a> {
+    /// A notification that supports all of the iOS features
+    Default(DefaultSound<'a>),
+    /// Safari web push notification
+    WebPush(&'a str),
 }

--- a/src/request/payload.rs
+++ b/src/request/payload.rs
@@ -4,6 +4,7 @@ use crate::request::notification::{DefaultAlert, DefaultSound, NotificationOptio
 use erased_serde::Serialize;
 use serde_json::{self, Value};
 use std::collections::BTreeMap;
+use std::fmt::Debug;
 
 /// The data and options for a push notification.
 #[derive(Debug, Clone, Serialize)]
@@ -51,7 +52,7 @@ pub struct Payload<'a> {
 ///     Ok(())
 /// }
 ///
-/// #[derive(Serialize)]
+/// #[derive(Serialize, Debug)]
 /// struct Payload<'a> {
 ///     aps: APS<'a>,
 ///     my_custom_value: String,
@@ -70,7 +71,7 @@ pub struct Payload<'a> {
 ///     }
 /// }
 /// ```
-pub trait PayloadLike: serde::Serialize {
+pub trait PayloadLike: serde::Serialize + Debug {
     /// Combine the APS payload and the custom data to a final payload JSON.
     /// Returns an error if serialization fails.
     #[allow(clippy::wrong_self_convention)]

--- a/src/request/payload.rs
+++ b/src/request/payload.rs
@@ -224,6 +224,8 @@ pub enum APSAlert<'a> {
     Default(DefaultAlert<'a>),
     /// Safari web push notification
     WebPush(WebPushAlert<'a>),
+    /// A notification with just a body
+    Body(&'a str),
 }
 
 /// Different notification sound types.


### PR DESCRIPTION
# Description

* Adds critical alert support ([See Apple's docs](https://developer.apple.com/documentation/usernotifications/unauthorizationoptions/2963120-criticalalert))
* Allows for custom `Serialize` implementations for the APNS payload. This means users can add custom fields inside the `aps` key (a bad idea for new software, but unfortunately we're kinda stuck with old apps that read custom data from weird places)

<!--
Please include:
* summary of the changes and the related issue
* relevant motivation and context
-->


## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

- `cargo test` passes
- Have been successfully sending pushes to our app with critical alerts and custom keys in `aps`.

<!-- If valid for smoke test on feature add screenshots -->

## Due Dilligence

Not sure if I'm filling these out correctly:
* [x] Breaking change (Users need to import `PayloadLike`. Maybe we could have dummy functions that replicate the functionality on the struct itself? Not sure if that'll work or if it's worth doing though)
* [x] Requires a documentation update (I believe I did this, so not sure if I should check it or not)
* [x] Requires a e2e/integration test update (Same as above)

Would really love for someone to code review this and let me know if there's anything I can improve on!