### PR TITLE
Add apns-push-type header

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -190,6 +190,7 @@ mod tests {
     use crate::request::notification::NotificationBuilder;
     use crate::request::notification::{CollapseId, NotificationOptions, Priority};
     use crate::signer::Signer;
+    use crate::PushType;
     use http::header::{AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE};
     use hyper::Method;
     use hyper_alpn::AlpnConnector;
@@ -280,6 +281,21 @@ jDwmlD1Gg0yJt1e38djFwsxsfr5q2hv0Rj9fTEqAPr8H7mGm0wKxZ7iQ
         let request = client.build_request(payload);
 
         assert_ne!(None, request.headers().get(AUTHORIZATION));
+    }
+
+    #[test]
+    fn test_request_with_background_type() {
+        let builder = DefaultNotificationBuilder::new();
+        let options = NotificationOptions {
+            apns_push_type: Some(PushType::Background),
+            ..Default::default()
+        };
+        let payload = builder.build("a_test_id", options);
+        let client = Client::new(AlpnConnector::new(), None, Endpoint::Production);
+        let request = client.build_request(payload);
+        let apns_push_type = request.headers().get("apns-push-type").unwrap();
+
+        assert_eq!("background", apns_push_type);
     }
 
     #[test]

--- a/src/client.rs
+++ b/src/client.rs
@@ -155,6 +155,9 @@ impl Client {
         if let Some(apns_id) = options.apns_id {
             builder = builder.header("apns-id", apns_id.as_bytes());
         }
+        if let Some(apns_push_type) = options.apns_push_type.as_ref() {
+            builder = builder.header("apns-push-type", apns_push_type.to_string().as_bytes());
+        }
         if let Some(ref apns_expiration) = options.apns_expiration {
             builder = builder.header("apns-expiration", apns_expiration.to_string().as_bytes());
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,8 +123,8 @@ pub mod response;
 mod signer;
 
 pub use crate::request::notification::{
-    CollapseId, DefaultNotificationBuilder, NotificationBuilder, NotificationOptions, Priority, WebNotificationBuilder,
-    WebPushAlert,
+    CollapseId, DefaultNotificationBuilder, NotificationBuilder, NotificationOptions, Priority, PushType,
+    WebNotificationBuilder, WebPushAlert,
 };
 
 pub use crate::response::{ErrorBody, ErrorReason, Response};

--- a/src/request/notification.rs
+++ b/src/request/notification.rs
@@ -4,7 +4,7 @@ mod options;
 mod web;
 
 pub use self::default::{DefaultAlert, DefaultNotificationBuilder, DefaultSound};
-pub use self::options::{CollapseId, NotificationOptions, Priority};
+pub use self::options::{CollapseId, NotificationOptions, Priority, PushType};
 pub use self::web::{WebNotificationBuilder, WebPushAlert};
 
 use crate::request::payload::Payload;

--- a/src/request/notification/options.rs
+++ b/src/request/notification/options.rs
@@ -19,7 +19,7 @@ impl<'a> CollapseId<'a> {
     }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 /// The apns-push-type header field has the following valid values.
 /// The descriptions below describe when and how to use these values.
 /// Send an apns-push-type header with each push. Recent and upcoming features

--- a/src/request/notification/options.rs
+++ b/src/request/notification/options.rs
@@ -19,6 +19,54 @@ impl<'a> CollapseId<'a> {
     }
 }
 
+#[derive(Default, Debug, Clone)]
+/// The apns-push-type header field has the following valid values.
+/// The descriptions below describe when and how to use these values.
+/// Send an apns-push-type header with each push. Recent and upcoming features
+/// may not work if this header is missing. See the table above to determine if
+/// this header is required or optional.
+///
+/// see https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns#4294485
+pub enum PushType {
+    /// The push type for notifications that trigger a user interaction—for example,
+    /// an alert, badge, or sound.
+    #[default]
+    Alert,
+    /// The push type for notifications that deliver content in the background, and
+    /// don’t trigger any user interactions.
+    Background,
+    /// The push type for notifications that request a user’s location.
+    Location,
+    /// The push type for notifications that provide information about an incoming
+    /// Voice-over-IP (VoIP) call.
+    Voip,
+    /// The push type to signal changes to a File Provider extension.
+    FileProvider,
+    /// The push type for notifications that tell managed devices to contact the
+    /// MDM server.
+    Mdm,
+    ///  The push type to signal changes to a live activity session.
+    LiveActivity,
+    /// The push type for notifications that provide information about updates to
+    /// your application’s push to talk services.
+    PushToTalk,
+}
+
+impl fmt::Display for PushType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            PushType::Alert => "alert",
+            PushType::Background => "background",
+            PushType::Location => "location",
+            PushType::Voip => "voip",
+            PushType::FileProvider => "fileprovider",
+            PushType::Mdm => "mdm",
+            PushType::LiveActivity => "liveactivity",
+            PushType::PushToTalk => "pushtotalk",
+        })
+    }
+}
+
 /// Headers to specify options to the notification.
 #[derive(Debug, Default, Clone)]
 pub struct NotificationOptions<'a> {
@@ -26,6 +74,12 @@ pub struct NotificationOptions<'a> {
     /// sending the notification, APNs uses this value to identify the
     /// notification to your server.
     pub apns_id: Option<&'a str>,
+
+    /// The apns-push-type header field has the following valid values.
+    ///
+    /// Recent and upcoming features may not work if this header is missing.
+    /// See the table above to determine if this header is required or optional.
+    pub apns_push_type: Option<PushType>,
 
     /// A UNIX epoch date expressed in seconds (UTC). This header identifies the
     /// date when the notification is no longer valid and can be discarded.


### PR DESCRIPTION
Set the `apns-push-type` header (mostly to support background notifications, but I mapped all the possible values).

## Due Dilligence

* [ ] Breaking change
* [x] Requires a documentation update
* [ ] Requires a e2e/integration test update