### PR TITLE
fix: Add tcp feature to hyper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ erased-serde = "0.3"
 serde_json = "1"
 thiserror = "1"
 openssl = { version = "0.10", optional = true }
-hyper = { version = "0.14", default-features = false, features = ["client", "http2"] }
+hyper = { version = "0.14", default-features = false, features = ["client", "http2", "tcp"] }
 hyper-alpn = "0.4"
 http = "0.2"
 base64 = "0.20"
@@ -39,4 +39,3 @@ ring = { version = "0.16", features = ["std"], optional = true }
 argparse = "0.2"
 tracing-subscriber = "0.3"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
-hyper = { version = "0.14", features = ["client", "http2", "tcp"] }


### PR DESCRIPTION
Prevents `executor must be set` panic when hyper with tcp enabled is not already in the dependencies of the project.

# Description

* Add tcp feature to hyper

I suggest to release a new version once this is merged since a2 cannot work for anybody not having `hyper ^0.14` with `tcp` feat enabled in the dependencies.

Resolves #76 

## How Has This Been Tested?

Used this as a path dependency in [this project](https://github.com/threema-ch/push-relay)

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update