### PR TITLE
Resolve unwrap in build body and when acquiring RwLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "openssl",
+ "parking_lot",
  "pem",
  "ring",
  "rustls",
@@ -341,6 +342,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +463,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.4",
+]
+
+[[package]]
 name = "pem"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +549,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469052894dcb553421e483e4209ee581a45100d31b4018de03e5a7ad86374a7e"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -584,6 +627,12 @@ name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ ring = { version = "0.17", features = ["std"], optional = true }
 hyper-rustls = { version = "0.26.0", default-features = false, features = ["http2", "webpki-roots", "ring"] }
 rustls-pemfile = "2.1.1"
 rustls = "0.22.0"
+parking_lot = "0.12"
 
 [dev-dependencies]
 argparse = "0.2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,10 @@ pub enum Error {
     #[error("Error building TLS config: {0}")]
     Tls(#[from] rustls::Error),
 
+    /// Error while creating the HTTP request
+    #[error("Failed to construct HTTP request: {0}")]
+    BuildRequestError(#[source] http::Error),
+
     /// Unexpected private key (only EC keys are supported).
     #[cfg(all(not(feature = "openssl"), feature = "ring"))]
     #[error("Unexpected private key: {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,8 @@
 //! }
 //! # }
 //! ```
+#![warn(clippy::unwrap_used)]
+
 #[cfg(not(any(feature = "openssl", feature = "ring")))]
 compile_error!("either feature \"openssl\" or feature \"ring\" has to be enabled");
 

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -1,10 +1,8 @@
 use crate::error::Error;
+use parking_lot::RwLock;
 use std::io::Read;
 use std::sync::Arc;
-use std::{
-    sync::RwLock,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use base64::prelude::*;
 #[cfg(feature = "openssl")]
@@ -138,7 +136,7 @@ impl Signer {
             self.renew()?;
         }
 
-        let signature = self.signature.read().unwrap();
+        let signature = self.signature.read();
 
         #[cfg(feature = "tracing")]
         {
@@ -191,7 +189,7 @@ impl Signer {
             );
         }
 
-        let mut signature = self.signature.write().unwrap();
+        let mut signature = self.signature.write();
 
         *signature = Signature {
             key: Self::create_signature(&self.secret, &self.key_id, &self.team_id, issued_at)?,
@@ -202,7 +200,7 @@ impl Signer {
     }
 
     fn is_expired(&self) -> bool {
-        let sig = self.signature.read().unwrap();
+        let sig = self.signature.read();
         let expiry = get_time() - sig.issued_at;
         expiry >= self.expire_after_s.as_secs() as i64
     }


### PR DESCRIPTION
# Description

The current version does panic if a RwLock is poisoned and also when a HTTP request could not be constructed **from the given user data**.

This PR replaces the RwLocks with the ones from parking_lot that do not have poison errors and adds propagation of errors happening when building the http request.

Resolves #69

## How Has This Been Tested?

A test has been written for the invalid payload.

## Due Dilligence

* [x] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update