### PR TITLE
feat: Add option to set a request timeout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ hyper-rustls = { version = "0.26.0", default-features = false, features = ["http
 rustls-pemfile = "2.1.1"
 rustls = "0.22.4"
 parking_lot = "0.12"
+tokio = { version = "1", features = ["time"] }
 
 [dev-dependencies]
 argparse = "0.2"

--- a/examples/certificate_client.rs
+++ b/examples/certificate_client.rs
@@ -43,7 +43,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             };
 
             let mut certificate = std::fs::File::open(certificate_file)?;
-            Ok(Client::certificate(&mut certificate, &password, endpoint)?)
+
+            // Create config with the given endpoint and default timeouts
+            let client_config = a2::ClientConfig::new(endpoint);
+
+            Ok(Client::certificate(&mut certificate, &password, client_config)?)
         }
         #[cfg(all(not(feature = "openssl"), feature = "ring"))]
         {

--- a/examples/token_client.rs
+++ b/examples/token_client.rs
@@ -1,7 +1,9 @@
 use argparse::{ArgumentParser, Store, StoreOption, StoreTrue};
 use std::fs::File;
 
-use a2::{Client, DefaultNotificationBuilder, Endpoint, NotificationBuilder, NotificationOptions};
+use a2::{
+    client::ClientConfig, Client, DefaultNotificationBuilder, Endpoint, NotificationBuilder, NotificationOptions,
+};
 
 // An example client connectiong to APNs with a JWT token
 #[tokio::main]
@@ -46,8 +48,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Endpoint::Production
     };
 
+    // Create config with the given endpoint and default timeouts
+    let client_config = ClientConfig::new(endpoint);
+
     // Connecting to APNs
-    let client = Client::token(&mut private_key, key_id, team_id, endpoint).unwrap();
+    let client = Client::token(&mut private_key, key_id, team_id, client_config).unwrap();
 
     let options = NotificationOptions {
         apns_topic: topic.as_deref(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,10 @@ pub enum Error {
     #[error("Failed to construct HTTP request: {0}")]
     BuildRequestError(#[source] http::Error),
 
+    /// No repsonse from APNs after the given amount of time
+    #[error("The request timed out after {0} s")]
+    RequestTimeout(u64),
+
     /// Unexpected private key (only EC keys are supported).
     #[cfg(all(not(feature = "openssl"), feature = "ring"))]
     #[error("Unexpected private key: {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@
 //! ## Example sending a plain notification using token authentication:
 //!
 //! ```no_run
-//! # use a2::{DefaultNotificationBuilder, NotificationBuilder, Client, Endpoint};
+//! # use a2::{DefaultNotificationBuilder, NotificationBuilder, Client, ClientConfig, Endpoint};
 //! # use std::fs::File;
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -48,7 +48,7 @@
 //!     &mut file,
 //!     "KEY_ID",
 //!     "TEAM_ID",
-//!     Endpoint::Production).unwrap();
+//!     ClientConfig::default()).unwrap();
 //!
 //! let response = client.send(payload).await?;
 //! println!("Sent: {:?}", response);
@@ -64,7 +64,7 @@
 //! # {
 //!
 //! use a2::{
-//!     Client, Endpoint, DefaultNotificationBuilder, NotificationBuilder, NotificationOptions,
+//!     Client, ClientConfig, Endpoint, DefaultNotificationBuilder, NotificationBuilder, NotificationOptions,
 //!     Priority,
 //! };
 //! use std::fs::File;
@@ -97,7 +97,7 @@
 //!     let client = Client::certificate(
 //!         &mut file,
 //!         "Correct Horse Battery Stable",
-//!         Endpoint::Production)?;
+//!         ClientConfig::default())?;
 //!
 //!     let response = client.send(payload).await?;
 //!     println!("Sent: {:?}", response);
@@ -131,6 +131,6 @@ pub use crate::request::notification::{
 
 pub use crate::response::{ErrorBody, ErrorReason, Response};
 
-pub use crate::client::{Client, Endpoint};
+pub use crate::client::{Client, ClientConfig, Endpoint};
 
 pub use crate::error::Error;

--- a/src/request/payload.rs
+++ b/src/request/payload.rs
@@ -27,11 +27,9 @@ pub struct Payload<'a> {
 ///
 /// # Example
 /// ```no_run
-/// use a2::client::Endpoint;
 /// use a2::request::notification::{NotificationBuilder, NotificationOptions};
 /// use a2::request::payload::{PayloadLike, APS};
-/// use a2::Client;
-/// use a2::DefaultNotificationBuilder;
+/// use a2::{Client, ClientConfig, DefaultNotificationBuilder, Endpoint};
 /// use serde::Serialize;
 /// use std::fs::File;
 ///
@@ -45,7 +43,7 @@ pub struct Payload<'a> {
 ///     let payload = builder.build("device-token-from-the-user", Default::default());
 ///     let mut file = File::open("/path/to/private_key.p8")?;
 ///
-///     let client = Client::token(&mut file, "KEY_ID", "TEAM_ID", Endpoint::Production).unwrap();
+///     let client = Client::token(&mut file, "KEY_ID", "TEAM_ID", ClientConfig::default()).unwrap();
 ///
 ///     let response = client.send(payload).await?;
 ///     println!("Sent: {:?}", response);


### PR DESCRIPTION
# Description

Adds the option to set a timeout on requests. For that, the existing options `endpoint` and `signer` are moved to a new `ClientOptions` struct that also allows setting the pool and request timeout (in seconds).

Resolves #73

## How Has This Been Tested?

This has not yet been tested since my testing framework of choice (`wiremock`) does not support setting a timeout.

## Due Dilligence

* [x] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update